### PR TITLE
🔨 Add Terragrunt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To disable output formatting (colors, bold text, etc.):
 tftree -no-color
 ```
 
+To use a different Terraform binary, like Terragrunt for example:
+
+```bash
+tftree -terraform-bin=terragrunt
+```
+
 ## License
 
 The code is licensed under the permissive Apache v2.0 license. [Read this](<https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)>) for a summary.

--- a/internal/terraform/runner.go
+++ b/internal/terraform/runner.go
@@ -13,12 +13,14 @@ import (
 )
 
 type runner struct {
-	workdir string
+	workdir      string
+	terraformBin string
 }
 
-func NewRunner(workdir string) *runner {
+func NewRunner(workdir, terraformBin string) *runner {
 	r := runner{
-		workdir: workdir,
+		workdir:      workdir,
+		terraformBin: terraformBin,
 	}
 
 	return &r
@@ -71,7 +73,7 @@ func (r *runner) Version() (*semver.Version, error) {
 }
 
 func (r *runner) runCommand(args []string, out io.Writer) error {
-	cmd := exec.Command("terraform", args...)
+	cmd := exec.Command(r.terraformBin, args...)
 
 	var buf bytes.Buffer
 	cmd.Stdout = &buf

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func run() error {
 		workdir = "."
 	}
 
-	tf := terraform.NewRunner(workdir)
+	tf := terraform.NewRunner(workdir, terraformBin)
 
 	logln("Running \"terraform init\"...")
 	err := tf.Init()
@@ -75,11 +75,13 @@ func logln(msg string) {
 var (
 	noColor      bool
 	printVersion bool
+	terraformBin string
 )
 
 func parseFlags() {
 	flag.BoolVar(&noColor, "no-color", false, "disable color in output")
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+	flag.StringVar(&terraformBin, "terraform-bin", "terraform", "terraform binary to use")
 
 	flag.Parse()
 }


### PR DESCRIPTION
This PR adds a `-terraform-bin` flag that allows using a different
Terraform binary. This is useful for using Terragrunt, for example.
