### PR TITLE
fix: use `flag.Args()` instead of `os.Args()` for leftover argument parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,14 +33,15 @@ func run() error {
 		return nil
 	}
 
+	args := flag.Args()
 	var workdir string
-	switch {
-	case len(os.Args) > 2:
-		return fmt.Errorf("too many arguments, must be either 0 or 1")
-	case len(os.Args) == 2:
-		workdir = os.Args[1]
-	default:
+	switch len(args) {
+	case 0:
 		workdir = "."
+	case 1:
+		workdir = args[0]
+	default:
+		return fmt.Errorf("too many arguments, must be either 0 or 1")
 	}
 
 	tf := terraform.NewRunner(workdir, terraformBin)


### PR DESCRIPTION
while testing the formula build in https://github.com/chenrui333/homebrew-tap/pull/111, found some arg parsing issue, updating to use `flag.Args()` instead of `os.Args()`.